### PR TITLE
Fix source package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include submodules/LRSplines/include/LRSpline/*.h


### PR DESCRIPTION
Choose to use cython or not at installation time. To use cython, it must be installed AND the pyx sources must be in the tree. If either condition is invalidated (for example, when installing via a source tarball), the cythonized C++ sources must be in the tree.