### PR TITLE
Basisfunction.support()

### DIFF
--- a/lrspline/__init__.py
+++ b/lrspline/__init__.py
@@ -546,6 +546,9 @@ class LRSplineSurface(LRSplineObject):
     def bezier_extraction(self, iEl):
         return self.w.getBezierExtraction(iEl)
 
+    def get_element_at(self, u, v):
+        return self.elements[self.w.getElementContaining(u,v)]
+
     __call__ = evaluate
 
 
@@ -598,6 +601,9 @@ class LRSplineVolume(LRSplineObject):
 
     def bezier_extraction(self, iEl):
         return self.w.getBezierExtraction(iEl)
+
+    def get_element_at(self, u, v, w):
+        return self.elements[self.w.getElementContaining(u,v,w)]
 
     def derivative(self, u, v, w, d=(1,1,1), iel=-1):
         wrapper = lambda u,v,w,n: self.w.point(u, v, w, n, iEl=iel)

--- a/lrspline/__init__.py
+++ b/lrspline/__init__.py
@@ -546,7 +546,7 @@ class LRSplineSurface(LRSplineObject):
     def bezier_extraction(self, iEl):
         return self.w.getBezierExtraction(iEl)
 
-    def get_element_at(self, u, v):
+    def element_at(self, u, v):
         return self.elements[self.w.getElementContaining(u,v)]
 
     __call__ = evaluate
@@ -602,7 +602,7 @@ class LRSplineVolume(LRSplineObject):
     def bezier_extraction(self, iEl):
         return self.w.getBezierExtraction(iEl)
 
-    def get_element_at(self, u, v, w):
+    def element_at(self, u, v, w):
         return self.elements[self.w.getElementContaining(u,v,w)]
 
     def derivative(self, u, v, w, d=(1,1,1), iel=-1):

--- a/lrspline/__init__.py
+++ b/lrspline/__init__.py
@@ -143,6 +143,10 @@ class BasisFunction(SimpleWrapper):
     def __getitem__(self, idx):
         return self.w.getknots(idx)
 
+    def __eq__(self, other):
+        if not isinstance(other, BasisFunction): return False
+        return self.id == other.id
+
     __call__ = evaluate
 
     def refine(self):
@@ -186,6 +190,10 @@ class Element(SimpleWrapper):
     def refine(self):
         self.lr.w.refineElement(self.id)
         self.lr.w.generateIDs()
+
+    def __eq__(self, other):
+        if not isinstance(other, Element): return False
+        return self.id == other.id
 
 
 class MeshInterface(SimpleWrapper):

--- a/lrspline/__init__.py
+++ b/lrspline/__init__.py
@@ -140,6 +140,10 @@ class BasisFunction(SimpleWrapper):
             wrapper = lambda u,v,w,n: self.w.evaluate(u, v, w, n, True, True, True )
         return _derivative_helper(pts, d, wrapper)
 
+    def support(self):
+        for w in self.w.supportIter():
+            yield Element(self.lr, w)
+
     def __getitem__(self, idx):
         return self.w.getknots(idx)
 

--- a/lrspline/__init__.py
+++ b/lrspline/__init__.py
@@ -148,7 +148,8 @@ class BasisFunction(SimpleWrapper):
         return self.w.getknots(idx)
 
     def __eq__(self, other):
-        if not isinstance(other, BasisFunction): return False
+        if not isinstance(other, BasisFunction):
+            return False
         return self.id == other.id
 
     __call__ = evaluate
@@ -196,7 +197,8 @@ class Element(SimpleWrapper):
         self.lr.w.generateIDs()
 
     def __eq__(self, other):
-        if not isinstance(other, Element): return False
+        if not isinstance(other, Element):
+            return False
         return self.id == other.id
 
 

--- a/lrspline/raw.pyx
+++ b/lrspline/raw.pyx
@@ -39,6 +39,8 @@ cdef extern from 'LRSpline/Basisfunction.h' namespace 'LR':
         double evaluate(double u, double v, double w, bool u_from_right, bool v_from_right, bool w_from_right) const
         void evaluate(vector[double]& results, double u, double v, double w, int derivs, bool u_from_right, bool v_from_right, bool w_from_right) const
         vector[double]& getknots(int i)
+        vector[Element_*].iterator supportedElementBegin()
+        vector[Element_*].iterator supportedElementEnd()
 
 cdef extern from 'LRSpline/Element.h' namespace 'LR':
     cdef cppclass Element_ 'LR::Element':
@@ -221,6 +223,15 @@ cdef class Basisfunction:
 
     def getknots(self, idx):
         return np.array(self.w.getknots(idx))
+
+    def supportIter(self):
+        cdef vector[Element_*].iterator it = self.w.supportedElementBegin()
+        cdef vector[Element_*].iterator end = self.w.supportedElementEnd()
+        while it != end:
+            el = Element()
+            el.w = deref(it)
+            yield el
+            preinc(it)
 
 
 cdef class Element:

--- a/lrspline/raw.pyx
+++ b/lrspline/raw.pyx
@@ -140,6 +140,7 @@ cdef extern from 'LRSpline/LRSplineSurface.h' namespace 'LR':
         int nMeshlines() const
         Meshline_* getMeshline(int i)
         void getBezierExtraction(int iEl, vector[double]& extractionMatrix)
+        int getElementContaining(double u, double v)
 
 cdef extern from 'LRSpline/LRSplineVolume.h' namespace 'LR':
     cdef cppclass LRSplineVolume_ 'LR::LRSplineVolume' (LRSpline_):
@@ -162,6 +163,7 @@ cdef extern from 'LRSpline/LRSplineVolume.h' namespace 'LR':
         MeshRectangle_* getMeshRectangle(int i)
         MeshRectangle_* insert_line(MeshRectangle_* newRect)
         void getBezierExtraction(int iEl, vector[double]& extractionMatrix)
+        int getElementContaining(double u, double v, double w)
 
 
 def _is_start(stream):
@@ -591,6 +593,9 @@ cdef class LRSurface(LRSplineObject):
         (<LRSplineSurface_*> self.w).getBezierExtraction(iEl, result)
         return np.reshape(result, (height, width), order='F')
 
+    def getElementContaining(self, double u, double v):
+        return (<LRSplineSurface_*> self.w).getElementContaining(u,v)
+
 
 cdef class LRVolume(LRSplineObject):
 
@@ -717,3 +722,6 @@ cdef class LRVolume(LRSplineObject):
         height = self.w.getElement(iEl).nBasisFunctions()
         (<LRSplineVolume_*> self.w).getBezierExtraction(iEl, result)
         return np.reshape(result, (height, width))
+
+    def getElementContaining(self, double u, double v, double w):
+        return (<LRSplineVolume_*> self.w).getElementContaining(u,v,w)

--- a/tests/test_surface.py
+++ b/tests/test_surface.py
@@ -164,3 +164,12 @@ def test_get_controlpoint():
     # all controlpoints srf[i] should equal the greville absiccae
     for i,bf in enumerate(srf.basis):
         np.testing.assert_allclose(srf[i], [np.mean(bf[0][1:3]), np.mean(bf[1][1:3])])
+
+
+def test_equality(srf):
+    bf = srf.basis[0]
+    for b in srf.elements[0].support():
+        if b.id == 0:
+            assert b == bf
+        else:
+            assert not b == bf

--- a/tests/test_surface.py
+++ b/tests/test_surface.py
@@ -11,6 +11,19 @@ def srf():
     with open(path / 'mesh01.lr', 'rb') as f:
         return lr.LRSplineSurface(f)
 
+@fixture
+# quadratic function, random function refined three times
+def srf2():
+    p = np.array([3,3]) # order=3
+    n = p + 7           # 8 elements
+    srf = lr.LRSplineSurface(n[0], n[1], p[0], p[1])
+    srf.basis[34].refine()
+    srf.basis[29].refine()
+    srf.basis[100].refine()
+    with open('ex.eps', 'wb') as f:
+        srf.write_postscript(f)
+    return srf
+
 
 def test_raw_constructors():
     srf = raw.LRSurface()
@@ -173,3 +186,19 @@ def test_equality(srf):
             assert b == bf
         else:
             assert not b == bf
+
+
+def test_support(srf2):
+    # check that all element -> basisfunction pointers are consistent
+    for bf in srf2.basis:
+        for el in bf.support():
+            assert bf in el.support()
+
+    # check that all basisfunction -> element pointers are consistent
+    for el in srf2.elements:
+        for bf in el.support():
+            assert el in bf.support()
+
+    # check that the 'in' call does as intended
+    assert not srf2.basis[0] in srf2.elements[1].support()
+

--- a/tests/test_surface.py
+++ b/tests/test_surface.py
@@ -188,6 +188,25 @@ def test_equality(srf):
             assert not b == bf
 
 
+def test_get_element_at(srf):
+    for el in srf.elements:
+        midpoint = (np.array(el.start()) + np.array(el.end())) / 2.0
+        el2 = srf.get_element_at(*midpoint)
+        assert el == el2
+
+    el1 = srf.elements[0]
+    el2 = srf.elements[1]
+    assert not el1 == el2
+
+    pt = (np.array(el2.start()) + np.array(el2.end())) / 2.0
+    el2 = srf.get_element_at(*pt)
+    assert not el1 == el2
+
+    pt = (np.array(el1.start()) + np.array(el1.end())) / 2.0
+    el2 = srf.get_element_at(*pt)
+    assert el1 == el2
+
+
 def test_support(srf2):
     # check that all element -> basisfunction pointers are consistent
     for bf in srf2.basis:

--- a/tests/test_surface.py
+++ b/tests/test_surface.py
@@ -188,10 +188,10 @@ def test_equality(srf):
             assert not b == bf
 
 
-def test_get_element_at(srf):
+def test_element_at(srf):
     for el in srf.elements:
         midpoint = (np.array(el.start()) + np.array(el.end())) / 2.0
-        el2 = srf.get_element_at(*midpoint)
+        el2 = srf.element_at(*midpoint)
         assert el == el2
 
     el1 = srf.elements[0]
@@ -199,11 +199,11 @@ def test_get_element_at(srf):
     assert not el1 == el2
 
     pt = (np.array(el2.start()) + np.array(el2.end())) / 2.0
-    el2 = srf.get_element_at(*pt)
+    el2 = srf.element_at(*pt)
     assert not el1 == el2
 
     pt = (np.array(el1.start()) + np.array(el1.end())) / 2.0
-    el2 = srf.get_element_at(*pt)
+    el2 = srf.element_at(*pt)
     assert el1 == el2
 
 

--- a/tests/test_volume.py
+++ b/tests/test_volume.py
@@ -50,10 +50,10 @@ def test_vol_from_file(vol):
     assert len(vol.meshrects) == 189
 
 
-def test_get_element_at(vol):
+def test_element_at(vol):
     for el in vol.elements:
         midpoint = (np.array(el.start()) + np.array(el.end())) / 2.0
-        el2 = vol.get_element_at(*midpoint)
+        el2 = vol.element_at(*midpoint)
         assert el == el2
 
     el1 = vol.elements[0]
@@ -61,11 +61,11 @@ def test_get_element_at(vol):
     assert not el1 == el2
 
     pt = (np.array(el2.start()) + np.array(el2.end())) / 2.0
-    el2 = vol.get_element_at(*pt)
+    el2 = vol.element_at(*pt)
     assert not el1 == el2
 
     pt = (np.array(el1.start()) + np.array(el1.end())) / 2.0
-    el2 = vol.get_element_at(*pt)
+    el2 = vol.element_at(*pt)
     assert el1 == el2
 
 

--- a/tests/test_volume.py
+++ b/tests/test_volume.py
@@ -50,6 +50,25 @@ def test_vol_from_file(vol):
     assert len(vol.meshrects) == 189
 
 
+def test_get_element_at(vol):
+    for el in vol.elements:
+        midpoint = (np.array(el.start()) + np.array(el.end())) / 2.0
+        el2 = vol.get_element_at(*midpoint)
+        assert el == el2
+
+    el1 = vol.elements[0]
+    el2 = vol.elements[1]
+    assert not el1 == el2
+
+    pt = (np.array(el2.start()) + np.array(el2.end())) / 2.0
+    el2 = vol.get_element_at(*pt)
+    assert not el1 == el2
+
+    pt = (np.array(el1.start()) + np.array(el1.end())) / 2.0
+    el2 = vol.get_element_at(*pt)
+    assert el1 == el2
+
+
 def test_evaluate():
     # testing identity mapping x(u,v) = u; y(u,v) = v
     srf = lr.LRSplineVolume(2,2,2,2,2,2)


### PR DESCRIPTION
Note that the equality testing introduced here does the simplified testing of the `id`-tag. This is contrast of what the underlying c++ library does, which traverses the entire knot vectors and have a much stricter definition of equality. The equality test is central to the refinement scheme since functions are split and spawn new ones all the time during refinement. However I don't expect the python library to ever spawn new `BasisFunction` objects of its own, since this should exclusively be the job of the c++ implementation and one might get away with the simplified equality testing.

As an added bonus it might even be faster since its only comparing a single number instead of all of the knot vectors.