### PR TITLE
Switchable ownership for MeshRectangle objects

### DIFF
--- a/lrspline/__init__.py
+++ b/lrspline/__init__.py
@@ -635,7 +635,7 @@ class LRSplineVolume(LRSplineObject):
         self.w.generateIDs()
 
     def insert(self, mr):
-        self.w.insert_line(mr.w.copy())
+        self.w.insert_line(mr.w)
 
     def evaluate(self, u, v, w, iel=-1):
         if isinstance(u, np.ndarray) and isinstance(v, np.ndarray) and isinstance(w, np.ndarray):


### PR DESCRIPTION
After the MeshRectangle constructor was introduced it became impossible to simply wrap MeshRectangle pointers that we get from the LRSpline classes. To fix this, allow a no-arguments constructor. Further, let MeshRectangle objects track whether the wrapped pointer is owned or not. When creating new ones via the regular 6/7-argument constructor, the pointer is owned and must be freed, but the pointers obtained from the LRSpline class getters are not owned.

It's a sin of the highest order to call the no-argument constructor without calling set_wrappee afterwards.

This also lets us use `.copy()` safely in the LRSplineVolume.insert_line method, since now the MeshRectangle can delete itself when going out of scope, no memory should be leaked by using this incorrectly. That also means we don't have to use `.copy()` in the pure Python interface.