### PR TITLE
Bezier extraction

### DIFF
--- a/lrspline/raw.pyx
+++ b/lrspline/raw.pyx
@@ -741,7 +741,7 @@ cdef class LRVolume(LRSplineObject):
         width  = self.w.order(0) * self.w.order(1) * self.w.order(2)
         height = self.w.getElement(iEl).nBasisFunctions()
         (<LRSplineVolume_*> self.w).getBezierExtraction(iEl, result)
-        return np.reshape(result, (height, width))
+        return np.reshape(result, (height, width), order='F')
 
     def getElementContaining(self, double u, double v, double w):
         return (<LRSplineVolume_*> self.w).getElementContaining(u,v,w)

--- a/tests/benchmark_test.py
+++ b/tests/benchmark_test.py
@@ -1,0 +1,69 @@
+import unittest
+import pytest
+import numpy as np
+import lrspline as lr
+import numpy as np
+from splipy import BSplineBasis
+from scipy import linalg
+
+def get_volume(p, n, nref):
+  vol    = lr.LRSplineVolume(*n, *p)
+  for i in range(nref):
+    el = vol.element_at(.24, .32, .16)
+    el2 = vol.element_at(.74, .62, .16)
+    functions = [func for func in el.support()] + [func for func in el2.support()]
+    vol.refine(functions)
+  return vol
+
+def get_bezier_basis(p):
+  b1 = BSplineBasis(p[0])
+  b2 = BSplineBasis(p[1])
+  b3 = BSplineBasis(p[2])
+  return (b1,b2,b3)
+
+def eval_bezier(spline, bezier, nviz):
+  el = np.random.choice(spline.elements)
+  B = el.bezier_extraction()
+  cp = np.array([func.controlpoint for func in el.support()])
+  for u in np.linspace(0,1,nviz):
+    for v in np.linspace(0,1,nviz):
+      for w in np.linspace(0,1,nviz):
+        bez = np.kron(bezier[2](w), np.kron(bezier[1](v), bezier[0](u)))
+        value = bez @ B.T @ cp
+
+def eval_call(spline, nviz):
+  el = np.random.choice(spline.elements)
+  for u in np.linspace(el.start(0), el.end(0), nviz):
+    for v in np.linspace(el.start(1), el.end(1), nviz):
+      for w in np.linspace(el.start(2), el.end(2), nviz):
+        value = spline(u,v,w)
+
+@pytest.mark.benchmark(group="eval-vol-nviz5")
+def test_eval_nviz5(benchmark):
+  p = np.array([3,3,3]) # quadratic functions (this is order, polynomial degree+1)
+  n = p + 3             # number of basis functions, start with 4x4 elements
+  spline = get_volume(p,n, 1)
+  benchmark(eval_call, spline, 5)
+
+@pytest.mark.benchmark(group="eval-vol-nviz5")
+def test_bezier_nviz5(benchmark):
+  p = np.array([3,3,3]) # quadratic functions (this is order, polynomial degree+1)
+  n = p + 3             # number of basis functions, start with 4x4 elements
+  spline = get_volume(p,n, 1)
+  bezier = get_bezier_basis(p)
+  benchmark(eval_bezier, spline, bezier, 5)
+
+@pytest.mark.benchmark(group="eval-vol-nviz2")
+def test_eval_nviz2(benchmark):
+  p = np.array([3,3,3]) # quadratic functions (this is order, polynomial degree+1)
+  n = p + 3             # number of basis functions, start with 4x4 elements
+  spline = get_volume(p,n, 1)
+  benchmark(eval_call, spline, 2)
+
+@pytest.mark.benchmark(group="eval-vol-nviz2")
+def test_bezier_nviz2(benchmark):
+  p = np.array([3,3,3]) # quadratic functions (this is order, polynomial degree+1)
+  n = p + 3             # number of basis functions, start with 4x4 elements
+  spline = get_volume(p,n, 1)
+  bezier = get_bezier_basis(p)
+  benchmark(eval_bezier, spline, bezier, 2)

--- a/tests/benchmark_test.py
+++ b/tests/benchmark_test.py
@@ -21,7 +21,38 @@ def get_bezier_basis(p):
   b3 = BSplineBasis(p[2])
   return (b1,b2,b3)
 
+def get_all_bezier_evaluations(p,nviz):
+  b1 = BSplineBasis(p[0])
+  b2 = BSplineBasis(p[1])
+  b3 = BSplineBasis(p[2])
+  result = []
+  for u in np.linspace(0,1,nviz):
+    for v in np.linspace(0,1,nviz):
+      for w in np.linspace(0,1,nviz):
+        bez = np.kron(b3(w), np.kron(b2(v), b1(u)))
+        result += [bez]
+  return result
+
 def eval_bezier(spline, bezier, nviz):
+  for el in spline.elements:
+    cp = np.array([func.controlpoint for func in el.support()])
+    B = el.bezier_extraction()
+    k = 0
+    for u in np.linspace(0,1,nviz):
+      for v in np.linspace(0,1,nviz):
+        for w in np.linspace(0,1,nviz):
+          bez = bezier[k]
+          k += 1
+          value = bez @ B.T @ cp
+
+def eval_call(spline, nviz):
+  for el in spline.elements:
+    for u in np.linspace(el.start(0), el.end(0), nviz):
+      for v in np.linspace(el.start(1), el.end(1), nviz):
+        for w in np.linspace(el.start(2), el.end(2), nviz):
+          value = spline(u,v,w)
+
+def eval_single_element_bezier(spline, bezier, nviz):
   el = np.random.choice(spline.elements)
   B = el.bezier_extraction()
   cp = np.array([func.controlpoint for func in el.support()])
@@ -31,12 +62,57 @@ def eval_bezier(spline, bezier, nviz):
         bez = np.kron(bezier[2](w), np.kron(bezier[1](v), bezier[0](u)))
         value = bez @ B.T @ cp
 
-def eval_call(spline, nviz):
+def eval_single_element_call(spline, nviz):
   el = np.random.choice(spline.elements)
   for u in np.linspace(el.start(0), el.end(0), nviz):
     for v in np.linspace(el.start(1), el.end(1), nviz):
       for w in np.linspace(el.start(2), el.end(2), nviz):
         value = spline(u,v,w)
+
+@pytest.mark.benchmark(group="eval-vol-single-nviz5")
+def test_eval_single_nviz5(benchmark):
+  p = np.array([3,3,3]) # quadratic functions (this is order, polynomial degree+1)
+  n = p + 3             # number of basis functions, start with 4x4 elements
+  spline = get_volume(p,n, 2)
+  benchmark(eval_single_element_call, spline, 5)
+
+@pytest.mark.benchmark(group="eval-vol-single-nviz5")
+def test_bezier_single_nviz5(benchmark):
+  p = np.array([3,3,3]) # quadratic functions (this is order, polynomial degree+1)
+  n = p + 3             # number of basis functions, start with 4x4 elements
+  spline = get_volume(p,n, 2)
+  bezier = get_bezier_basis(p)
+  benchmark(eval_single_element_bezier, spline, bezier, 5)
+
+@pytest.mark.benchmark(group="eval-vol-single-nviz2")
+def test_eval_single_nviz2(benchmark):
+  p = np.array([3,3,3]) # quadratic functions (this is order, polynomial degree+1)
+  n = p + 3             # number of basis functions, start with 4x4 elements
+  spline = get_volume(p,n, 2)
+  benchmark(eval_single_element_call, spline, 2)
+
+@pytest.mark.benchmark(group="eval-vol-single-nviz2")
+def test_bezier_single_nviz2(benchmark):
+  p = np.array([3,3,3]) # quadratic functions (this is order, polynomial degree+1)
+  n = p + 3             # number of basis functions, start with 4x4 elements
+  spline = get_volume(p,n, 2)
+  bezier = get_bezier_basis(p)
+  benchmark(eval_single_element_bezier, spline, bezier, 2)
+
+@pytest.mark.benchmark(group="eval-vol-nviz2")
+def test_eval_nviz2(benchmark):
+  p = np.array([3,3,3]) # quadratic functions (this is order, polynomial degree+1)
+  n = p + 3             # number of basis functions, start with 4x4 elements
+  spline = get_volume(p,n, 2)
+  benchmark(eval_call, spline, 2)
+
+@pytest.mark.benchmark(group="eval-vol-nviz2")
+def test_bezier_nviz2(benchmark):
+  p = np.array([3,3,3]) # quadratic functions (this is order, polynomial degree+1)
+  n = p + 3             # number of basis functions, start with 4x4 elements
+  spline = get_volume(p,n, 2)
+  bezier = get_all_bezier_evaluations(p, 2)
+  benchmark(eval_bezier, spline, bezier, 2)
 
 @pytest.mark.benchmark(group="eval-vol-nviz5")
 def test_eval_nviz5(benchmark):
@@ -50,20 +126,5 @@ def test_bezier_nviz5(benchmark):
   p = np.array([3,3,3]) # quadratic functions (this is order, polynomial degree+1)
   n = p + 3             # number of basis functions, start with 4x4 elements
   spline = get_volume(p,n, 1)
-  bezier = get_bezier_basis(p)
+  bezier = get_all_bezier_evaluations(p, 5)
   benchmark(eval_bezier, spline, bezier, 5)
-
-@pytest.mark.benchmark(group="eval-vol-nviz2")
-def test_eval_nviz2(benchmark):
-  p = np.array([3,3,3]) # quadratic functions (this is order, polynomial degree+1)
-  n = p + 3             # number of basis functions, start with 4x4 elements
-  spline = get_volume(p,n, 1)
-  benchmark(eval_call, spline, 2)
-
-@pytest.mark.benchmark(group="eval-vol-nviz2")
-def test_bezier_nviz2(benchmark):
-  p = np.array([3,3,3]) # quadratic functions (this is order, polynomial degree+1)
-  n = p + 3             # number of basis functions, start with 4x4 elements
-  spline = get_volume(p,n, 1)
-  bezier = get_bezier_basis(p)
-  benchmark(eval_bezier, spline, bezier, 2)


### PR DESCRIPTION
Added benchmark test (as well as some unit tests for evaluation) to see how much difference bezier extraction makes for evaluation in the python wrapping.

Basically it only makes a difference for enough evaluation points and if you reuse the bezier evaluations globally and it is not worth it if you only evaluate a single element (or if one re-evaluates the bezier basis for every element).

This is in contrast to lower-level implementations such as IFEM  which enjoy much faster speedup for much more general cases.

```
------------------------------------------------------------------------- benchmark 'eval-vol-nviz2': 2 tests --------------------------------------------------------------------------
Name (time in ms)          Min                 Max                Mean            StdDev              Median               IQR            Outliers     OPS            Rounds  Iterations
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_bezier_nviz2     677.8180 (1.0)      696.1384 (1.01)     683.9589 (1.0)      7.2968 (6.03)     683.1920 (1.0)      8.3211 (4.75)          1;0  1.4621 (1.0)           5           1
test_eval_nviz2       688.1437 (1.02)     691.2337 (1.0)      689.6530 (1.01)     1.2097 (1.0)      689.2412 (1.01)     1.7501 (1.0)           2;0  1.4500 (0.99)          5           1
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--------------------------------------------------------------------- benchmark 'eval-vol-nviz5': 2 tests ----------------------------------------------------------------------
Name (time in s)         Min               Max              Mean            StdDev            Median               IQR            Outliers     OPS            Rounds  Iterations
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_bezier_nviz5     2.9563 (1.0)      2.9680 (1.0)      2.9617 (1.0)      0.0046 (1.0)      2.9613 (1.0)      0.0074 (1.30)          2;0  0.3376 (1.0)           5           1
test_eval_nviz5       6.3121 (2.14)     6.3277 (2.13)     6.3231 (2.13)     0.0063 (1.36)     6.3249 (2.14)     0.0057 (1.0)           1;1  0.1581 (0.47)          5           1
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

----------------------------------------------------------------------- benchmark 'eval-vol-single-nviz2': 2 tests -----------------------------------------------------------------------
Name (time in ms)               Min                Max              Mean            StdDev            Median               IQR            Outliers       OPS            Rounds  Iterations
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_eval_single_nviz2       4.0598 (1.0)      27.3027 (1.0)      5.3245 (1.0)      3.7506 (1.0)      4.1842 (1.0)      0.1360 (1.0)         17;34  187.8122 (1.0)         202           1
test_bezier_single_nviz2     6.8750 (1.69)     30.8091 (1.13)     8.2350 (1.55)     3.8641 (1.03)     7.0834 (1.69)     0.2545 (1.87)        11;13  121.4334 (0.65)        137           1
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

------------------------------------------------------------------------- benchmark 'eval-vol-single-nviz5': 2 tests ------------------------------------------------------------------------
Name (time in ms)                Min                Max               Mean            StdDev             Median               IQR            Outliers       OPS            Rounds  Iterations
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_eval_single_nviz5        7.4709 (1.0)      22.3597 (1.0)       8.8032 (1.0)      3.5848 (1.0)       7.7299 (1.0)      0.2398 (1.0)          9;11  113.5951 (1.0)         108           1
test_bezier_single_nviz5     47.9463 (6.42)     71.2190 (3.19)     50.0085 (5.68)     5.0992 (1.42)     48.6431 (6.29)     0.7375 (3.07)          2;2   19.9966 (0.18)         21           1
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

Legend:
  Outliers: 1 Standard Deviation from Mean; 1.5 IQR (InterQuartile Range) from 1st Quartile and 3rd Quartile.
  OPS: Operations Per Second, computed as 1 / Mean
===================================================================================================== 8 passed in 81.75 seconds =====================================================================================================
```
